### PR TITLE
Small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A subset of the [M/Monit HTTP API](http://mmonit.com/documentation/http-api/) co
             :username => 'USERNAME',
             :password => 'PASSWORD',
             :address => 'example.com',
-            :port => '443'
+            :port => 443
     })
 
     mmonit.connect

--- a/lib/mmonit/connection.rb
+++ b/lib/mmonit/connection.rb
@@ -43,6 +43,10 @@ module MMonit
 			self.request('/z_security_check', URI.encode_www_form({'z_username'=>@username, 'z_password'=>@password, 'z_csrf_protection'=>'off'}), true).code.to_i == 302
 		end
 
+		def logout
+			self.request('/login/logout.csp')
+		end
+
 		# Status API: http://mmonit.com/documentation/http-api/Methods/Status
 		def status
 			JSON.parse(self.request('/status/hosts/list').body)['records']

--- a/lib/mmonit/connection.rb
+++ b/lib/mmonit/connection.rb
@@ -23,7 +23,8 @@ module MMonit
 				'Referer' => "#{@url}/index.csp",
 				'Content-Type' => 'application/x-www-form-urlencoded',
 				'User-Agent' => @useragent,
-				'Connection' => 'Keep-Alive'
+				'Connection' => 'Keep-Alive',
+				'Accept-Encoding' => 'identity'
 			}
 		end
 

--- a/lib/mmonit/connection.rb
+++ b/lib/mmonit/connection.rb
@@ -10,7 +10,7 @@ module MMonit
 		def initialize(options = {})
 			@ssl = options[:ssl] || false
 			@address = options[:address]
-			options[:port] ||= @ssl ? '8443' : '8080'
+			options[:port] ||= @ssl ? 8443 : 8080
 			@port = options[:port]
 			@username = options[:username]
 			@password = options[:password]

--- a/lib/mmonit/connection.rb
+++ b/lib/mmonit/connection.rb
@@ -37,7 +37,15 @@ module MMonit
 			end
 
 			@headers['Cookie'] = @http.get('/index.csp').response['set-cookie'].split(';').first
-			self.login
+			login
+		end
+
+		def disconnect
+			return unless @http.is_a?(Net::HTTP)
+
+			logout
+			@http = nil
+			@headers['Cookie'] = nil;
 		end
 
 		def login
@@ -47,6 +55,8 @@ module MMonit
 		def logout
 			self.request('/login/logout.csp')
 		end
+
+		private :logout
 
 		# Status API: http://mmonit.com/documentation/http-api/Methods/Status
 		def status

--- a/lib/mmonit/connection.rb
+++ b/lib/mmonit/connection.rb
@@ -40,7 +40,7 @@ module MMonit
 		end
 
 		def login
-			self.request('/z_security_check', "z_username=#{@username}&z_password=#{@password}", true).code.to_i == 302
+			self.request('/z_security_check', URI.encode_www_form({'z_username'=>@username, 'z_password'=>@password, 'z_csrf_protection'=>'off'}), true).code.to_i == 302
 		end
 
 		# Status API: http://mmonit.com/documentation/http-api/Methods/Status


### PR DESCRIPTION
I added proper encoding of the login credentials, so if they contain symbols it will still work.
Also added the `logout` method as described in the spec. Might come in handy.
